### PR TITLE
fix: Responsiveness for low width

### DIFF
--- a/src/energy-overview-card.ts
+++ b/src/energy-overview-card.ts
@@ -98,7 +98,7 @@ export class EnergyOverviewCard extends LitElement {
 
       .line svg {
         width: 100%;
-        height: 15px;
+        padding-bottom: 3px;
       }
 
       .line svg path {


### PR DESCRIPTION
SVG line was not responsive in smaller size, it had overflow on the left. 

Removing height solved the issue, but aligned the svg lower to the bottom compared to the original solution, which seemed to be fixed by adding 3px padding to the bottom.

**Before:**
![image](https://github.com/Sese-Schneider/ha-energy-overview-card/assets/26442204/e79f6db6-bf4e-4835-8830-cccd94bc3a0b)

**After:**
![image](https://github.com/Sese-Schneider/ha-energy-overview-card/assets/26442204/16ccfe97-df17-400b-81f5-fff3aceb5041)
